### PR TITLE
Updates seed-breakpoints prop-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "node-sass": "^3.8.0"
   },
   "dependencies": {
-    "seed-breakpoints": "0.2.0"
+    "seed-breakpoints": "0.2.1"
   }
 }

--- a/scss/pack/seed-typography/_config.scss
+++ b/scss/pack/seed-typography/_config.scss
@@ -5,7 +5,7 @@ $seed-typography-namespace: "t" !default;
 $seed-typography-alignment-namespace: $seed-typography-namespace !default;
 $seed-typography-break-namespace: #{$seed-typography-namespace}-break !default;
 $seed-typography-decoration-namespace: $seed-typography-namespace !default;
-$seed-typography-heading-namespace: #{$seed-typography-namespace}-h !default;
+$seed-typography-heading-namespace: #{$seed-typography-namespace} !default;
 $seed-typography-headline-namespace: #{$seed-typography-namespace}-headline !default;
 $seed-typography-line-height-namespace: #{$seed-typography-namespace}-lh !default;
 $seed-typography-size-namespace: $seed-typography-namespace !default;
@@ -45,12 +45,12 @@ $seed-typography-decoration: (
 
 // Heading sizes
 $seed-typography-heading-sizes: (
-  1: 3rem,
-  2: 2.25rem,
-  3: 1.5rem,
-  4: 1.25rem,
-  5: 1rem,
-  6: 0.875rem
+  h1: 3rem,
+  h2: 2.25rem,
+  h3: 1.5rem,
+  h4: 1.25rem,
+  h5: 1rem,
+  h6: 0.875rem
 ) !default;
 
 // Headline sizes
@@ -63,7 +63,7 @@ $seed-typography-headline-sizes: (
 
 // Generic sizes
 $seed-typography-sizes: (
-  lead: map-get($seed-typography-heading-sizes, 4),
+  lead: map-get($seed-typography-heading-sizes, h4),
   xl: 1.28rem,
   lg: 1.14rem,
   md: 1rem,

--- a/scss/pack/seed-typography/functions/_heading.scss
+++ b/scss/pack/seed-typography/functions/_heading.scss
@@ -3,7 +3,7 @@
 // Dependencies
 @import "../config";
 
-@function t-heading($size: 1, $fallback: false) {
+@function t-heading($size: h1, $fallback: false) {
   @if map-has-key($seed-typography-heading-sizes, $size) {
     $heading: map-get($seed-typography-heading-sizes, $size);
     @return $heading;

--- a/scss/pack/seed-typography/type/_alignment.scss
+++ b/scss/pack/seed-typography/type/_alignment.scss
@@ -1,6 +1,6 @@
 // Type :: Alignment
 
-.#{$seed-typography-alignment-namespace}- {
+.#{$seed-typography-alignment-namespace} {
   @include prop-map($seed-typography-alignment, (prop)) {
     @if $seed-typography-use-important {
       text-align: prop(prop) !important;

--- a/scss/pack/seed-typography/type/_break.scss
+++ b/scss/pack/seed-typography/type/_break.scss
@@ -1,6 +1,6 @@
 // Type :: Break
 
-.#{$seed-typography-break-namespace}- {
+.#{$seed-typography-break-namespace} {
   @include prop-map($seed-typography-break, (prop)) {
     @if $seed-typography-use-important {
       word-break: prop(prop) !important;

--- a/scss/pack/seed-typography/type/_decoration.scss
+++ b/scss/pack/seed-typography/type/_decoration.scss
@@ -1,6 +1,6 @@
 // Type :: Decoration
 
-.#{$seed-typography-decoration-namespace}- {
+.#{$seed-typography-decoration-namespace} {
   @include prop-map($seed-typography-decoration, (prop)) {
     @if $seed-typography-use-important {
       text-decoration: prop(prop) !important;

--- a/scss/pack/seed-typography/type/_headline.scss
+++ b/scss/pack/seed-typography/type/_headline.scss
@@ -1,6 +1,6 @@
 // Type :: Headline
 
-.#{$seed-typography-headline-namespace}- {
+.#{$seed-typography-headline-namespace} {
   @include breakpoint-prop-map($seed-typography-headline-sizes, (font-size)) {
     @if $seed-typography-use-important {
       font-size: prop(font-size) !important;

--- a/scss/pack/seed-typography/type/_line-height.scss
+++ b/scss/pack/seed-typography/type/_line-height.scss
@@ -1,6 +1,6 @@
 // Type :: Line Height
 
-.#{$seed-typography-line-height-namespace}- {
+.#{$seed-typography-line-height-namespace} {
   @include breakpoint-prop-map($seed-typography-line-height, (size)) {
     @if $seed-typography-use-important {
       line-height: prop(size) !important;

--- a/scss/pack/seed-typography/type/_size.scss
+++ b/scss/pack/seed-typography/type/_size.scss
@@ -1,6 +1,6 @@
 // Type :: Size
 
-.#{$seed-typography-size-namespace}- {
+.#{$seed-typography-size-namespace} {
   @include prop-map($seed-typography-sizes, (font-size)) {
     @if $seed-typography-use-important {
       font-size: prop(font-size) !important;

--- a/scss/pack/seed-typography/type/_transform.scss
+++ b/scss/pack/seed-typography/type/_transform.scss
@@ -1,6 +1,6 @@
 // Type :: Transform
 
-.#{$seed-typography-transform-namespace}- {
+.#{$seed-typography-transform-namespace} {
   @include prop-map($seed-typography-transform, (prop)) {
     @if $seed-typography-use-important {
       text-transform: prop(prop) !important;

--- a/scss/pack/seed-typography/type/_weight.scss
+++ b/scss/pack/seed-typography/type/_weight.scss
@@ -5,7 +5,7 @@
 
 @include generate-typography-weight-num;
 
-.#{$seed-typography-weight-namespace}- {
+.#{$seed-typography-weight-namespace} {
   @include prop-map($seed-typography-weight, (weight)) {
     @if $seed-typography-use-important {
       font-weight: prop(weight) !important;

--- a/scss/pack/seed-typography/type/_white-space.scss
+++ b/scss/pack/seed-typography/type/_white-space.scss
@@ -1,6 +1,6 @@
 // Type :: White Space
 
-.#{$seed-typography-white-space-namespace}- {
+.#{$seed-typography-white-space-namespace} {
   @include prop-map($seed-typography-white-space, (prop)) {
     @if $seed-typography-use-important {
       white-space: prop(prop) !important;
@@ -10,4 +10,3 @@
     }
   }
 }
-

--- a/scss/pack/seed-typography/type/_wrap.scss
+++ b/scss/pack/seed-typography/type/_wrap.scss
@@ -1,6 +1,6 @@
 // Type :: Wrap
 
-.#{$seed-typography-wrap-namespace}- {
+.#{$seed-typography-wrap-namespace} {
   @include prop-map($seed-typography-wrap, (prop)) {
     @if $seed-typography-use-important {
       word-wrap: prop(prop) !important;


### PR DESCRIPTION
Removes the extra hyphen at the end of classnames to support how the new prop-maps works (yay).

Adjusted config maps to properly support this.
